### PR TITLE
Revert "fix: display overlayed modals properly"

### DIFF
--- a/modules/modal-promises/index.tsx
+++ b/modules/modal-promises/index.tsx
@@ -24,10 +24,9 @@ export function useModalPromises() {
   return React.useContext(ModalPromisesContext);
 }
 
-let nextId = 0;
-
 export function withModalPromises<P>(WrappedComponent: React.ComponentType<P>) {
   const WithModalPromises: React.ComponentType<P> = (props: P) => {
+    const [nextId, setNextId] = React.useState(0);
     const [nodes, setNodes] = React.useState<Record<number, React.ReactNode>>(
       {}
     );
@@ -40,7 +39,7 @@ export function withModalPromises<P>(WrappedComponent: React.ComponentType<P>) {
       render: RenderFunction<T>
     ) {
       return new Promise<T>((resolve, reject) => {
-        const id = nextId++;
+        const id = nextId;
         const node = render(
           (value) => {
             setNode(id, null);
@@ -51,6 +50,7 @@ export function withModalPromises<P>(WrappedComponent: React.ComponentType<P>) {
             reject(reason);
           }
         );
+        setNextId((value) => value + 1);
         setNode(id, node);
       });
     };

--- a/modules/teiki-ui/components/Modal/components/Container/index.module.scss
+++ b/modules/teiki-ui/components/Modal/components/Container/index.module.scss
@@ -1,11 +1,8 @@
-.portal {
-  z-index: 10;
-}
-
 .overlay {
   background-color: rgba(0, 0, 0, 0.44);
   position: fixed;
   inset: 0px;
+  z-index: 10;
 }
 
 .content {
@@ -14,6 +11,7 @@
   background-color: white;
   border-radius: 16px;
   position: fixed;
+  z-index: 11;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);

--- a/modules/teiki-ui/components/Modal/components/Container/index.tsx
+++ b/modules/teiki-ui/components/Modal/components/Container/index.tsx
@@ -43,7 +43,7 @@ export default function Container({
         onOpenChange && onOpenChange(open);
       }}
     >
-      <Dialog.Portal className={styles.portal}>
+      <Dialog.Portal>
         <Dialog.Overlay className={styles.overlay} />
         <Dialog.Content
           className={cx(className, styles.content, SIZE_TO_CLASS_NAME[size])}


### PR DESCRIPTION
Reverts teiki-network/teiki-web#29.

This seems to have broken the stake modals:
https://app.asana.com/0/1203842063837585/1204131242029317.