### PR TITLE
feat: display overlaid modals properly

### DIFF
--- a/modules/modal-promises/index.tsx
+++ b/modules/modal-promises/index.tsx
@@ -24,9 +24,10 @@ export function useModalPromises() {
   return React.useContext(ModalPromisesContext);
 }
 
+let nextId = 0;
+
 export function withModalPromises<P>(WrappedComponent: React.ComponentType<P>) {
   const WithModalPromises: React.ComponentType<P> = (props: P) => {
-    const [nextId, setNextId] = React.useState(0);
     const [nodes, setNodes] = React.useState<Record<number, React.ReactNode>>(
       {}
     );
@@ -39,7 +40,7 @@ export function withModalPromises<P>(WrappedComponent: React.ComponentType<P>) {
       render: RenderFunction<T>
     ) {
       return new Promise<T>((resolve, reject) => {
-        const id = nextId;
+        const id = nextId++;
         const node = render(
           (value) => {
             setNode(id, null);
@@ -50,7 +51,6 @@ export function withModalPromises<P>(WrappedComponent: React.ComponentType<P>) {
             reject(reason);
           }
         );
-        setNextId((value) => value + 1);
         setNode(id, node);
       });
     };

--- a/modules/teiki-ui/components/Modal/components/Container/index.module.scss
+++ b/modules/teiki-ui/components/Modal/components/Container/index.module.scss
@@ -1,8 +1,12 @@
+.portal {
+  position: relative;
+  z-index: 10;
+}
+
 .overlay {
   background-color: rgba(0, 0, 0, 0.44);
   position: fixed;
   inset: 0px;
-  z-index: 10;
 }
 
 .content {
@@ -11,7 +15,6 @@
   background-color: white;
   border-radius: 16px;
   position: fixed;
-  z-index: 11;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);

--- a/modules/teiki-ui/components/Modal/components/Container/index.tsx
+++ b/modules/teiki-ui/components/Modal/components/Container/index.tsx
@@ -44,19 +44,21 @@ export default function Container({
       }}
     >
       <Dialog.Portal>
-        <Dialog.Overlay className={styles.overlay} />
-        <Dialog.Content
-          className={cx(className, styles.content, SIZE_TO_CLASS_NAME[size])}
-          style={style}
-          onEscapeKeyDown={
-            closeOnEscape ? undefined : (e) => e.preventDefault()
-          }
-          onPointerDownOutside={
-            closeOnDimmerClick ? undefined : (e) => e.preventDefault()
-          }
-        >
-          {children}
-        </Dialog.Content>
+        <div className={styles.portal}>
+          <Dialog.Overlay className={styles.overlay} />
+          <Dialog.Content
+            className={cx(className, styles.content, SIZE_TO_CLASS_NAME[size])}
+            style={style}
+            onEscapeKeyDown={
+              closeOnEscape ? undefined : (e) => e.preventDefault()
+            }
+            onPointerDownOutside={
+              closeOnDimmerClick ? undefined : (e) => e.preventDefault()
+            }
+          >
+            {children}
+          </Dialog.Content>
+        </div>
       </Dialog.Portal>
     </Dialog.Root>
   );


### PR DESCRIPTION
Resolves https://app.asana.com/0/1203842063837585/1203982387389794/f

Related to https://app.asana.com/0/1203842063837585/1204131242029317

---

**Explanation of the [previous bug](https://app.asana.com/0/1203842063837585/1204131242029317)**

`<Dialog.Portal className={styles.portal}>` from this [PR](https://github.com/teiki-network/teiki-web/pull/29) was incorrect, it attaches `styles.portal` to the implicit container, which is `document.body`. Basically it lifts everything up (regarding `z-index`), and when _everything_ is lifted up, _nothing_ is lifted up.

That was my fault for not checking the modal behaviour when it is displayed along other [positioned](https://developer.mozilla.org/en-US/docs/Web/CSS/position#types_of_positioning) elements.

---

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/117076162/223626858-3939e8e8-0b0d-43da-94b9-efc479938055.png">

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/117076162/223626941-eeda8e27-3133-4471-b8d9-e40dbd7386e9.png">
