### PR TITLE
refactor: split signing and submitting into two steps

### DIFF
--- a/containers/PageEditProject/containers/ModalGroup$CreateProject/components/ModalSubmit/index.tsx
+++ b/containers/PageEditProject/containers/ModalGroup$CreateProject/components/ModalSubmit/index.tsx
@@ -131,10 +131,19 @@ export default function ModalSubmit({
         }
       );
 
-      setStatusBarText("Waiting for signature and submission...");
-      const txHash: string = await signAndSubmit(txComplete).catch((cause) => {
-        console.error({ txComplete }); // for debugging purpose
-        throw DisplayableError.from(cause, "Failed to sign or submit");
+      setStatusBarText("Waiting for signature...");
+      const txCompleteSigned = await txComplete
+        .sign()
+        .complete()
+        .catch((cause) => {
+          console.error({ txComplete }); // for debugging purpose
+          throw DisplayableError.from(cause, "Failed to sign");
+        });
+
+      setStatusBarText("Waiting for submission...");
+      const txHash = await txCompleteSigned.submit().catch((cause) => {
+        console.error({ txCompleteSigned });
+        throw DisplayableError.from(cause, "Failed to submit");
       });
 
       setStatusBarText("Waiting for confirmation...");

--- a/containers/PageProjectDetails/containers/ModalBackProject/index.tsx
+++ b/containers/PageProjectDetails/containers/ModalBackProject/index.tsx
@@ -129,10 +129,19 @@ export default function ModalBackProject({
         throw DisplayableError.from(cause, "Failed to build transaction");
       });
 
-      setStatusBarText("Waiting for signature and submission...");
-      const txHash: string = await signAndSubmit(txComplete).catch((cause) => {
-        console.error({ txComplete }); // for debugging purpose
-        throw DisplayableError.from(cause, "Failed to sign or submit");
+      setStatusBarText("Waiting for signature...");
+      const txCompleteSigned = await txComplete
+        .sign()
+        .complete()
+        .catch((cause) => {
+          console.error({ txComplete }); // for debugging purpose
+          throw DisplayableError.from(cause, "Failed to sign");
+        });
+
+      setStatusBarText("Waiting for submission...");
+      const txHash = await txCompleteSigned.submit().catch((cause) => {
+        console.error({ txCompleteSigned });
+        throw DisplayableError.from(cause, "Failed to submit");
       });
 
       setStatusBarText("Waiting for confirmation...");

--- a/containers/PageProjectDetails/containers/PanelAdjustStake/containers/ModalUnbackProject/index.tsx
+++ b/containers/PageProjectDetails/containers/PanelAdjustStake/containers/ModalUnbackProject/index.tsx
@@ -150,10 +150,19 @@ export default function ModalUnbackProject({
         throw DisplayableError.from(cause, "Failed to build transaction");
       });
 
-      setStatusBarText("Waiting for signature and submission...");
-      const txHash: string = await signAndSubmit(txComplete).catch((cause) => {
-        console.error({ txComplete }); // for debugging purpose
-        throw DisplayableError.from(cause, "Failed to sign or submit");
+      setStatusBarText("Waiting for signature...");
+      const txCompleteSigned = await txComplete
+        .sign()
+        .complete()
+        .catch((cause) => {
+          console.error({ txComplete }); // for debugging purpose
+          throw DisplayableError.from(cause, "Failed to sign");
+        });
+
+      setStatusBarText("Waiting for submission...");
+      const txHash = await txCompleteSigned.submit().catch((cause) => {
+        console.error({ txCompleteSigned });
+        throw DisplayableError.from(cause, "Failed to submit");
       });
 
       setStatusBarText("Waiting for confirmation...");

--- a/containers/PageProjectDetails/containers/PanelProtocolReward/utils/submitClaimTeikiTx.ts
+++ b/containers/PageProjectDetails/containers/PanelProtocolReward/utils/submitClaimTeikiTx.ts
@@ -68,10 +68,20 @@ export async function submitClaimTeikiTx({
       throw DisplayableError.from(cause, "Failed to build transaction");
     }
   );
-  onProgress && onProgress("Waiting for signature and submission...");
-  const txHash: string = await signAndSubmit(txComplete).catch((cause) => {
-    console.error({ txComplete }); // for debugging purpose
-    throw DisplayableError.from(cause, "Failed to sign or submit");
+
+  onProgress && onProgress("Waiting for signature...");
+  const txCompleteSigned = await txComplete
+    .sign()
+    .complete()
+    .catch((cause) => {
+      console.error({ txComplete }); // for debugging purpose
+      throw DisplayableError.from(cause, "Failed to sign");
+    });
+
+  onProgress && onProgress("Waiting for submission...");
+  const txHash = await txCompleteSigned.submit().catch((cause) => {
+    console.error({ txCompleteSigned });
+    throw DisplayableError.from(cause, "Failed to submit");
   });
 
   onProgress && onProgress("Waiting for confirmation...");

--- a/containers/PageProjectDetails/containers/ProjectOverview/containers/ModalCloseProject/index.tsx
+++ b/containers/PageProjectDetails/containers/ProjectOverview/containers/ModalCloseProject/index.tsx
@@ -103,10 +103,19 @@ export default function ModalCloseProject({
         throw DisplayableError.from(cause, "Failed to build transaction");
       });
 
-      setStatusBarText("Waiting for signature and submission...");
-      const txHash: string = await signAndSubmit(txComplete).catch((cause) => {
-        console.error({ txComplete }); // for debugging purpose
-        throw DisplayableError.from(cause, "Failed to sign or submit");
+      setStatusBarText("Waiting for signature...");
+      const txCompleteSigned = await txComplete
+        .sign()
+        .complete()
+        .catch((cause) => {
+          console.error({ txComplete }); // for debugging purpose
+          throw DisplayableError.from(cause, "Failed to sign");
+        });
+
+      setStatusBarText("Waiting for submission...");
+      const txHash = await txCompleteSigned.submit().catch((cause) => {
+        console.error({ txCompleteSigned });
+        throw DisplayableError.from(cause, "Failed to submit");
       });
 
       setStatusBarText("Waiting for confirmation...");

--- a/containers/PageUpdateProjectV2/containers/ModalPostAnnouncement/index.tsx
+++ b/containers/PageUpdateProjectV2/containers/ModalPostAnnouncement/index.tsx
@@ -145,10 +145,19 @@ export default function ModalPostAnnouncement({
         throw DisplayableError.from(cause, "Failed to build transaction");
       });
 
-      setStatusBarText("Waiting for signature and submission...");
-      const txHash: string = await signAndSubmit(txComplete).catch((cause) => {
-        console.error({ txComplete }); // for debugging purpose
-        throw DisplayableError.from(cause, "Failed to sign or submit");
+      setStatusBarText("Waiting for signature...");
+      const txCompleteSigned = await txComplete
+        .sign()
+        .complete()
+        .catch((cause) => {
+          console.error({ txComplete }); // for debugging purpose
+          throw DisplayableError.from(cause, "Failed to sign");
+        });
+
+      setStatusBarText("Waiting for submission...");
+      const txHash = await txCompleteSigned.submit().catch((cause) => {
+        console.error({ txCompleteSigned });
+        throw DisplayableError.from(cause, "Failed to submit");
       });
 
       setStatusBarText("Waiting for confirmation...");

--- a/containers/PageUpdateProjectV2/containers/ModalUpdateProject/index.tsx
+++ b/containers/PageUpdateProjectV2/containers/ModalUpdateProject/index.tsx
@@ -196,10 +196,19 @@ export default function ModalUpdateProject({
         throw DisplayableError.from(cause, "Failed to build transaction");
       });
 
-      setStatusBarText("Waiting for signature and submission...");
-      const txHash = await signAndSubmit(txComplete).catch((cause) => {
-        console.error({ txComplete }); // for debugging purpose
-        throw DisplayableError.from(cause, "Failed to sign or submit");
+      setStatusBarText("Waiting for signature...");
+      const txCompleteSigned = await txComplete
+        .sign()
+        .complete()
+        .catch((cause) => {
+          console.error({ txComplete }); // for debugging purpose
+          throw DisplayableError.from(cause, "Failed to sign");
+        });
+
+      setStatusBarText("Waiting for submission...");
+      const txHash = await txCompleteSigned.submit().catch((cause) => {
+        console.error({ txCompleteSigned });
+        throw DisplayableError.from(cause, "Failed to submit");
       });
 
       setStatusBarText("Waiting for confirmation...");


### PR DESCRIPTION
Previously, user see:

**Waiting for signature and submission...**

Now user will see:

**Waiting for signature...**
**Waiting for submission...**

---

https://user-images.githubusercontent.com/117076162/223987643-e799b25d-bd12-41d2-bef1-c97d649757cb.mp4

---

Besides, this change helps us debug easier, by having the view access to the signed tx in case of failure.

---

