### PR TITLE
fix: getMaxLovelaceAmount now returns 0 if user too poor

### DIFF
--- a/containers/PageProjectDetails/containers/ModalBackProject/constants.ts
+++ b/containers/PageProjectDetails/containers/ModalBackProject/constants.ts
@@ -1,0 +1,4 @@
+import { LovelaceAmount } from "@/modules/business-types";
+
+export const MINIMUM_BACKING_AMOUNT: LovelaceAmount = 2000000;
+export const PADDING_LOVELACE_AMOUNT: LovelaceAmount = 5000000;

--- a/containers/PageProjectDetails/containers/ModalBackProject/hooks/useField.ts
+++ b/containers/PageProjectDetails/containers/ModalBackProject/hooks/useField.ts
@@ -1,5 +1,7 @@
 import React from "react";
 
+import { MINIMUM_BACKING_AMOUNT } from "../constants";
+
 import { parseLovelaceAmount } from "@/modules/bigint-utils";
 import { LovelaceAmount } from "@/modules/business-types";
 
@@ -20,12 +22,12 @@ export function useField$LovelaceAmount({
   const error =
     parsed == null
       ? "Invalid number"
-      : parsed < 2000000 // TODO: @sk-tenba: import this number from somewhere
+      : maxLovelaceAmount != null && maxLovelaceAmount < MINIMUM_BACKING_AMOUNT
+      ? "Insufficient ADA balance"
+      : parsed < MINIMUM_BACKING_AMOUNT
       ? "You must back at least 2 ADA"
-      : // TODO: @sk-kitsune: We should not use `maxLovelaceAmount`
-      // if it is not accurate.
-      maxLovelaceAmount && maxLovelaceAmount < parsed
-      ? "There is not sufficient ADA in your wallet"
+      : maxLovelaceAmount != null && maxLovelaceAmount < parsed
+      ? "Insufficient ADA balance"
       : undefined;
 
   // TODO: @sk-kitsune: we should also set onKeyDown at the call site

--- a/modules/teiki-components/components/InputLovelaceAmount/index.tsx
+++ b/modules/teiki-components/components/InputLovelaceAmount/index.tsx
@@ -55,9 +55,9 @@ export default function InputSupportedLovelaceAmount({
             <Button.Link
               className={styles.buttonMax}
               content="Max"
-              disabled={!maxLovelaceAmount || disabled}
+              disabled={maxLovelaceAmount == null || disabled}
               onClick={() =>
-                maxLovelaceAmount
+                maxLovelaceAmount != null
                   ? onChange(
                       formatLovelaceAmount(maxLovelaceAmount, {
                         excludeThousandsSeparator: true,


### PR DESCRIPTION
Resolves https://app.asana.com/0/1203842063837585/1204103332755267/f

## Summary

Previously, when user does not have enough money, the MAX button will be disabled. Now we enable it.

When user clicks it, it will fill the input with "0.000000", ~~so that user knows he is poor.~~

## Technical notes

- Previously, If user does not have enough ADAs, `useMaxLovelaceAmount` returns `undefined` instead of `0`. After this PR, it will return `0`.
- Previously `getMaxLovelaceAmount` uses `checked_sub`, which calculate A-B and throw an error in case of that A<B. Now we use `clamped_sub`, which calculates `max(0, A-B)`
- Previously, we check `!maxLovelaceAmount`, now we check `maxLovelaceAmount == null`.

## Displaying logic

```
 const error =
    parsed == null
      ? "Invalid number"
      : maxLovelaceAmount != null && maxLovelaceAmount < MINIMUM_BACKING_AMOUNT
      ? "Insufficient ADA balance"
      : parsed < MINIMUM_BACKING_AMOUNT
      ? "You must back at least 2 ADA"
      : maxLovelaceAmount != null && maxLovelaceAmount < parsed
      ? "Insufficient ADA balance"
      : undefined;
```

## Screencasts

Normal cases

https://user-images.githubusercontent.com/117076162/224948936-4ce62734-8d17-4616-864e-0e29ba03cf1d.mp4

When user is too poor (i.e. `maxLovelaceAmount < MINIMUM_BACKING_AMOUNT`)

https://user-images.githubusercontent.com/117076162/224948967-ea5b339e-4b1a-41a9-bdaa-6114eed840bd.mp4


